### PR TITLE
Add animation to flash messages and update views.

### DIFF
--- a/app/assets/stylesheets/flash_styling.css
+++ b/app/assets/stylesheets/flash_styling.css
@@ -8,3 +8,56 @@
 .alert {
   padding-left: 200px;
 }
+
+/* Delete lines 16 & 17 if we want left-sidebar to overlap flash message when animation ends */
+.animated {
+  -webkit-animation-duration: .5s;
+  animation-duration: .5s;
+  -webkit-animation-fill-mode: both;
+  animation-fill-mode: both;
+}
+
+@-webkit-keyframes shake {
+  from, to {
+    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
+  }
+
+  15%, 45%, 75% {
+    -webkit-transform: translate3d(-10px, 0, 0);
+    transform: translate3d(-10px, 0, 0);
+  }
+
+  30%, 60%, 90% {
+    -webkit-transform: translate3d(10px, 0, 0);
+    transform: translate3d(10px, 0, 0);
+  }
+}
+
+@keyframes shake {
+  from, to {
+    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
+  }
+
+  15%, 45%, 75% {
+    -webkit-transform: translate3d(-10px, 0, 0);
+    transform: translate3d(-10px, 0, 0);
+  }
+
+  30%, 60%, 90% {
+    -webkit-transform: translate3d(10px, 0, 0);
+    transform: translate3d(10px, 0, 0);
+  }
+}
+
+.shake {
+  -webkit-animation-name: shake;
+  animation-name: shake;
+}
+
+/* Makes links in flash appear blue & underlined (e.g., when removing event from cart) */
+.shake a {
+  color: #0080ff;
+  text-decoration: underline;
+}

--- a/app/mailers/user_notifier_mailer.rb
+++ b/app/mailers/user_notifier_mailer.rb
@@ -1,11 +1,11 @@
 class UserNotifierMailer < ApplicationMailer
-  default from: 'onefanstreasure@gmail.com'
+  default from: 'nosebleedtix@gmail.com'
 
   def send_signup_email(user)
     @user = user
     mail(
       to: @user.email,
-      subject: "Welcome to One Fan's Treasure!"
+      subject: "Welcome to Nosebleed Tickets!"
       )
   end
 

--- a/app/views/admin/events/new.html.erb
+++ b/app/views/admin/events/new.html.erb
@@ -1,4 +1,4 @@
 <div class="page-content">
-  <h1>Add New Treasure</h1>
-  <%= render partial: 'shared/event_form', locals: { path: admin_events_path, button: "Add Treasure" } %>
+  <h1>Add New Event</h1>
+  <%= render partial: 'shared/event_form', locals: { path: admin_events_path, button: "Add Event" } %>
 </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -2,7 +2,7 @@
   <h1>All Events</h1>
   <%= render partial: "filter" %>
   <% if current_admin? %>
-    <%= link_to 'Add New Treasure', new_admin_event_path, class: 'btn btn-lg btn-danger pull-right' %>
+    <%= link_to 'Add New Event', new_admin_event_path, class: 'btn btn-lg btn-danger pull-right' %>
   <% end %>
 
   <%= render partial: 'shared/event_list', locals: { btn_label: 'Add to Cart', btn_class: 'default', status: false} %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -3,10 +3,11 @@
     <h1><%= @event.title %></h1>
     <%= image_tag(@event.image_path, alt: "#{@event.title} pic", class: 'img-thumbnail show-image', style: 'float:left') %>
     <div class="event-content">
-      <h2><p>Venue: <strong><%= @event.venue_name %></strong></h2></p>
-      <h4><p>Category: <%= @event.category.title %></p></h4>
-      <p><%= @event.description %></p>
-      <p><%= number_to_currency(@event.price) %><p>
+      <h2><p><strong>Venue:</strong> <%= @event.venue_name %></h2></p>
+      <h4><p><strong>Category:</strong> <%= @event.category.title %></p></h4>
+      <br>
+      <p><em><%= @event.description %></em></p>
+      <p><strong><%= number_to_currency(@event.price) %></strong></p>
       <% if @event.past_event? %>
         <p><%= link_to 'SOLD OUT', cart_events_path(event_id: @event.id), class: 'btn btn-danger', disabled: 'disabled' %></p>
       <% else %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,8 +1,8 @@
 <div class="well col-md-8 center">
   <center>
-    <p>One Venue's Trash,</p>
-    <h1><font face='Passion One' size="50px">One Fan's Treasure</font></h1>
-    Be one with the stars by owning the everyday events that once lived in their homes! At <em>One Fan's Treasure</em>, we pride ourselves in providing a wide range of household and ordinary goods that were once graced by our planet's entertainment royalty. From cleaning to kitchen, vanity to household, we have everything you need to fulfill nearly any domestic-based and restraining-order-abiding fantasy.
-    <p><strong><font face='Montserrat'>You can't live with them, but you can live with the inanimate objects that have.</font></strong></p>
+    <h1><font face='Passion One' size="50px">Nosebleed Tickets</font></h1>
+    Nobody wants to sit so close to a basketball court that they can smell the players' sweat, or close enough to a stage that they might need to catch a crowd-surfing lead singer. Enjoy your favorite events the smart way, with <em>Nosebleed Tickets<sub><small>(TM)</small></sub></em>! No longer will you be forced to strain your neck or exhaust yourself with the constant head-turning needed to follow the action. From the nosebleeds, the entire event is within your view!<sup> *</sup>
   </center>
+  <br><br>
+  <sub><small>* Binoculars recommended (particularly the small kind with the handle, like you might expect to see in the audience at an opera or a ballet).</small></sub>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>One Fan's Treasure</title>
+    <title>Nosebleed Tickets</title>
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag    'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
@@ -10,7 +10,7 @@
   <body>
       <%= render '/shared/navbar' %>
       <% flash.each do |key, value| %>
-        <div class="alert alert-<%= key %> alert-dismissible text-center" role="alert">
+        <div class="alert alert-<%= key %> alert-dismissible text-center animated shake" role="alert">
           <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
           <%= sanitize(value) %>
         </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -7,7 +7,7 @@
       or login with <%= link_to "Twitter", twitter_login_path %>
     </p></center>
     <center><p>
-      New to One Fan's Treasure? <%= link_to "Create an account", new_user_path %>
+      New to Nosebleed Tickets? <%= link_to "Create an account", new_user_path %>
     </p></center>
   </div>
 </div>

--- a/app/views/shared/_event_form.html.erb
+++ b/app/views/shared/_event_form.html.erb
@@ -10,7 +10,7 @@
     </div>
     <div class="form-group">
       <%= f.label :price %>
-      <%= f.number_field :price, step: 'any', class: 'form-control' %>
+      <%= f.number_field :price, min: 0, step: 0.01, class: 'form-control' %>
     </div>
     <div class="form-group">
       <%= f.label :category_id %>

--- a/app/views/shared/_event_list.html.erb
+++ b/app/views/shared/_event_list.html.erb
@@ -9,7 +9,7 @@
           <%= image_tag(event.image_path, alt: "#{event.title} pic", class: 'img-thumbnail event-image') %>
         </p>
         <p>
-          Venue: <%= event.venue_name %>
+          <strong>Venue:</strong> <%= event.venue_name %>
         </p>
         <p>
           <%= number_to_currency(event.price) %>

--- a/app/views/shared/_login_form.html.erb
+++ b/app/views/shared/_login_form.html.erb
@@ -2,22 +2,22 @@
   <%= form_for(target, url: path) do |f|  %>
   <p>
     <%= f.label :username %>
-    <%= f.text_field :username, class: 'entry' %>
+    <%= f.text_field :username %>
   </p>
   <%  %>
   <% if new_user_path? || admin_edit? %>
   <p>
     <%= f.label :email %>
-    <%= f.text_field :email, class: 'entry' %>
+    <%= f.text_field :email %>
   </p>
   <% end %>
   <p>
     <%= f.label :password %>
-    <%= f.password_field :password, class: 'entry' %>
+    <%= f.password_field :password %>
   </p>
 
   <center>
     <%= f.submit button, class: "center_button btn btn-#{btn_class}"%>
   </center>
-  <% end %>  
+  <% end %>
 </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -35,7 +35,7 @@
       <% end %>
     </li>
     <li>
-      <%= mail_to "onefanstreasure@gmail.com" do %>
+      <%= mail_to "nosebleedtix@gmail.com" do %>
         <i class="fa fa-envelope"></i> Email Us
       <% end %>
     </li>

--- a/app/views/user_notifier_mailer/send_confirmation_email.html.erb
+++ b/app/views/user_notifier_mailer/send_confirmation_email.html.erb
@@ -1,6 +1,6 @@
 <h1>Order Confirmation</h1>
 <p>
-  Thank you for your order. Please find the details of your order below:
+  Thank you for your order! Please find the details of your order below:
 </p>
 <br />
 <div class="well col-md-12 table-responsive" id="order-<%= @order.id %>">
@@ -43,5 +43,5 @@
 </table>
 <br />
 <p>
-  Sincerely, <br />One Fan's Treasure
+  Sincerely, <br />Nosebleed Tickets
 </p>

--- a/app/views/user_notifier_mailer/send_signup_email.html.erb
+++ b/app/views/user_notifier_mailer/send_signup_email.html.erb
@@ -1,3 +1,3 @@
-<h1>Thanks for registering, <%= @user.username %>!</h1>
-<p>You're well on your way to a collection of incredible treasures.</p>
-<p>All the best, <br/ > One Fan's Treasures</p>
+<h1>Thank you for registering, <%= @user.username %>!</h1>
+<p>You are well on your way to seeing your favorite events live!</p>
+<p>All the best, <br/ > Nosebleed Tickets</p>

--- a/app/views/venues/index.html.erb
+++ b/app/views/venues/index.html.erb
@@ -7,10 +7,10 @@
           <%= image_tag(venue.image_path, alt: "#{venue.name} pic", class: 'img-thumbnail event-image') %>
         </p>
         <p>
-          Venue: <%= venue.name %>
+          <strong>Venue:</strong> <%= venue.name %>
         </p>
         <p>
-          Location: <%= venue.location %>
+          <strong>Location:</strong> <%= venue.location %>
         </p>
         <%= content_tag :div do %>
           <%= link_to "View Venue", venue_path(venue), class: "center_button btn btn-primary" %>

--- a/app/views/venues/show.html.erb
+++ b/app/views/venues/show.html.erb
@@ -4,10 +4,10 @@
     <%= image_tag(@venue.image_path, alt: "#{@venue.name} pic", class: 'img-thumbnail show-image', style: 'float:left') %>
     <div class="event-content">
       <p>
-        Location: <%= @venue.location %>
+        <strong>Location:</strong> <%= @venue.location %>
       </p>
       <p>
-        Capacity: <%= @venue.capacity %>
+        <strong>Capacity:</strong> <%= @venue.capacity %>
       </p>
     </div>
   </div>

--- a/spec/features/admin/admin_creates_an_event_spec.rb
+++ b/spec/features/admin/admin_creates_an_event_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Admin creates an event' do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
       visit events_path
-      click_on 'Add New Treasure'
+      click_on 'Add New Event'
 
       expect(current_path).to eq(new_admin_event_path)
 
@@ -19,7 +19,7 @@ RSpec.feature 'Admin creates an event' do
       fill_in 'Price', with: 29.99
       select "#{categories.first.title}", from: 'Category'
       select "#{venue.name}", from: 'Venue'
-      click_on 'Add Treasure'
+      click_on 'Add Event'
 
       expect(current_path).to eq(event_path(Event.first))
       expect(page).to have_content(Event.first.title)
@@ -38,7 +38,7 @@ RSpec.feature 'Admin creates an event' do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
       visit events_path
-      click_on 'Add New Treasure'
+      click_on 'Add New Event'
 
       fill_in 'Title', with: 'Creamy Ranch Dressing'
       fill_in 'Description', with: "It's not self-indulgent when it's the best. By Newman, for Newman."
@@ -47,7 +47,7 @@ RSpec.feature 'Admin creates an event' do
       select "#{venue.name}", from: 'Venue'
       # Commented out due to this being a static asset.
       # attach_file('Image', '/Users/Ryan/Desktop/No_available_image.gif')
-      click_on 'Add Treasure'
+      click_on 'Add Event'
 
       expect(current_path).to eq(event_path(Event.first))
       expect(page).to have_content(Event.first.title)
@@ -65,10 +65,10 @@ RSpec.feature 'Admin creates an event' do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
       visit events_path
-      click_on 'Add New Treasure'
+      click_on 'Add New Event'
       fill_in 'Title', with: event.title
       fill_in 'Description', with: event.description
-      click_on 'Add Treasure'
+      click_on 'Add Event'
 
       expect(page).to have_content("Title has already been taken, Price can't be blank")
       expect(Event.count).to eq(1)
@@ -82,7 +82,7 @@ RSpec.feature 'Admin creates an event' do
 
       visit events_path
 
-      expect(page).to_not have_link('Add New Treasure')
+      expect(page).to_not have_link('Add New Event')
     end
 
     scenario 'logged-in user attempts to visit new event path' do
@@ -98,7 +98,7 @@ RSpec.feature 'Admin creates an event' do
     scenario 'visitor visits the events path' do
       visit events_path
 
-      expect(page).to_not have_link('Add New Treasure')
+      expect(page).to_not have_link('Add New Event')
     end
 
     scenario 'visitor attempts to visit new event path' do

--- a/spec/features/user/user_sees_welcome_page_spec.rb
+++ b/spec/features/user/user_sees_welcome_page_spec.rb
@@ -4,6 +4,6 @@ RSpec.feature "User sees welcome page" do
   scenario "when they visit the root" do
     visit root_path
 
-    expect(page).to have_content("One Fan's Treasure")
+    expect(page).to have_content("Nosebleed Tickets")
   end
 end


### PR DESCRIPTION
- Added shake animation to flash messages.
- Added CSS to make links within flash messages (e.g., after removing an event from the cart) appear blue and underlined.
- Changed instances of 'One Fan's Treasure' to 'Nosebleed Tickets' in views, specs, and mailers.
- Changed instances of 'Treasure' (e.g., Add New Treasure) to 'Event' in views and specs.
- Added 'strong' styling to attribute names in Event and Venue index and show views to make more readable.
- Added a minimum to the Price field in the Event form (for adding/editing an event) so price cannot be set below 0.
