### PR TITLE
Close #5. Add functionality for admin to add event

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -6,9 +6,9 @@ class Admin::EventsController < Admin::BaseController
   end
 
   def create
-    @event = Event.new(event_params)
+    @event = Event.new(params_with_venue)
     if @event.save
-      flash[:success] = 'Treasure added successfully'
+      flash[:success] = 'Event Added Successfully!'
       redirect_to event_path(@event.venue, @event)
     else
       flash.now[:danger] = @event.errors.full_messages.join(', ')
@@ -34,11 +34,19 @@ class Admin::EventsController < Admin::BaseController
 
   def event_params
     params.require(:event).permit(:title,
-                                 :supporting_act,
-                                 :price,
-                                 :category_id,
-                                 :venue_id,
-                                 :upload_image)
+                                  :supporting_act,
+                                  :price,
+                                  :date,
+                                  :category_id,
+                                  :venue_id,
+                                  :upload_image)
+  end
+
+  def params_with_venue
+    return event_params if platform_admin?
+    form_params = event_params
+    form_params[:venue_id] = current_venue_admin.id
+    form_params
   end
 
   def set_event

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,11 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-  helper_method :current_user, :verify_logged_in, :categories, :current_admin?
+  helper_method :current_user,
+                :verify_logged_in,
+                :categories,
+                :current_admin?,
+                :platform_admin?,
+                :current_venue_admin
   before_action :set_cart
 
   def set_cart
@@ -22,15 +27,15 @@ class ApplicationController < ActionController::Base
     current_user && !current_user.customer?
   end
 
+  def platform_admin?
+    current_user && current_user.platform_admin?
+  end
+
+  def current_venue_admin
+    Venue.find_by(admin: current_user) if current_admin?
+  end
+
   def categories
     @categories = Category.all
   end
-
-  # def default_url_options
-  #   if Rails.env.production?
-  #     { host: 'nosebleed-tix.herokuapp.com'}
-  #   else
-  #     {}
-  #   end
-  # end
 end

--- a/app/helpers/venues_helper.rb
+++ b/app/helpers/venues_helper.rb
@@ -1,0 +1,5 @@
+module VenuesHelper
+  def this_venues_admin?
+    Venue.find_by_slug(params[:name]).admin == current_user
+  end
+end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -6,6 +6,7 @@
       <h2><p><strong>Venue:</strong> <%= @event.venue_name %></h2></p>
       <h4><p><strong>Category:</strong> <%= @event.category.title %></p></h4>
       <h4><p><strong>Featuring:</strong> <%= @event.supporting_act %></p></h4>
+      <h4><p><strong>Date:</strong> <%= @event.event_date %></p></h4>
       <br />
       <p><em>See the sights and hear the sounds at <%= @event.title %>, featuring <%= @event.supporting_act %>. Sure to be an unforgettable evening!</em></p>
       <br />

--- a/app/views/shared/_event_form.html.erb
+++ b/app/views/shared/_event_form.html.erb
@@ -9,6 +9,10 @@
       <%= f.text_field :supporting_act, class: 'form-control' %>
     </div>
     <div class="form-group">
+      <%= f.label :date %>
+      <%= f.date_field :date, class: 'form-control' %>
+    </div>
+    <div class="form-group">
       <%= f.label :price %>
       <%= f.number_field :price, min: 0, step: 0.01, class: 'form-control' %>
     </div>
@@ -16,14 +20,17 @@
       <%= f.label :category_id %>
       <%= f.select :category_id, event_categories, {}, class: 'form-control' %>
     </div>
-    <div class="form-group">
-      <%= f.label :venue_id %>
-      <%= f.select :venue_id, event_venues, {}, class: 'form-control' %>
-    </div>
-    <div class="form-group">
+    <% if platform_admin? %>
+      <div class="form-group">
+        <%= f.label :venue_id %>
+        <%= f.select :venue_id, event_venues, class: 'form-control' %>
+      </div>
+    <% end %>
+    <!-- Currently hidden due to this being tentative functionality -->
+    <!-- <div class="form-group">
       <%= f.label :upload_image, 'Image' %>
       <%= f.file_field :upload_image, class: 'center_button' %>
-    </div>
+    </div> -->
     <div class="form-group">
       <%= f.submit "#{button}", class: 'form-control btn btn-default' %>
     </div>

--- a/app/views/venues/show.html.erb
+++ b/app/views/venues/show.html.erb
@@ -9,37 +9,39 @@
       <p>
         <strong>Capacity:</strong> <%= @venue.capacity %>
       </p>
+      <% if this_venues_admin? %>
+        <p>
+          <%= link_to 'Add Event', new_admin_event_path, class: 'btn btn-default' %>
+        </p>
+      <% end %>
     </div>
-      <div class="table-responsive col-md-8 fit-width">
-        <table class="table">
-          <thead>
-            <tr>
-              <th>Event Name</th>
-              <th>Category</th>
-              <th>Date</th>
-              <th>Price</th>
-              <th>Purchase</th>
+    <div class="table-responsive col-md-8 fit-width">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Event Name</th>
+            <th>Category</th>
+            <th>Date</th>
+            <th>Price</th>
+            <th>Purchase</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @venue.events.each do |event| %>
+            <tr id="event-<%= event.id %>">
+              <td><%= event.title %></td>
+              <td><%= event.category.title %></td>
+              <td><%= event.event_date %></td>
+              <td><%= number_to_currency(event.price) %></td>
+              <td>
+                <%= content_tag :div do %>
+                  <%= button_to "Add to Cart", cart_events_path(event_id: event.id), class: "center_button btn btn-sm btn-primary" %>
+                <% end %>
+              </td>
             </tr>
-          </thead>
-          <tbody>
-            <% @venue.events.each do |event| %>
-              <tr id="event-<%= event.id %>">
-                <td><%= event.title %></td>
-                <td><%= event.category.title %></td>
-                <td><%= event.event_date %></td>
-                <td><%= number_to_currency(event.price) %></td>
-                <td>
-                  <%= content_tag :div do %>
-                    <%= button_to "Add to Cart", cart_events_path(event_id: event.id), class: "center_button btn btn-sm btn-primary" %>
-                  <% end %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
-
-
-
+          <% end %>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>

--- a/spec/features/admin/admin_creates_an_event_spec.rb
+++ b/spec/features/admin/admin_creates_an_event_spec.rb
@@ -1,73 +1,56 @@
 require 'rails_helper'
 
 RSpec.feature 'Admin creates an event' do
-  context 'with valid event infomation and no photo' do
-    scenario 'logged-in admin visits the events path' do
-      admin = create(:admin)
-      categories = create_list(:category, 3)
+  context 'logged-in event admin' do
+    scenario 'with valid event information' do
       venue = create(:venue)
+      admin = venue.admin
+      categories = create_list(:category, 3)
 
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+      allow_any_instance_of(ApplicationController).
+      to receive(:current_user).
+      and_return(admin)
 
-      visit events_path
-      click_on 'Add New Event'
+      expect(venue.events.count).to eq(0)
+
+      visit admin_dashboard_index_path
+      click_on 'View My Events'
+      click_on 'Add Event'
 
       expect(current_path).to eq(new_admin_event_path)
+      within('form') do
+        expect(page).to_not have_content('Venue')
+      end
 
-      fill_in 'Title', with: 'Creamy Ranch Dressing'
-      fill_in 'Supporting Act', with: "It's not self-indulgent when it's the best. By Newman, for Newman."
-      fill_in 'Price', with: 29.99
-      select "#{categories.first.title}", from: 'Category'
-      select "#{venue.name}", from: 'Venue'
+      fill_in 'Title', with: 'Colorado Rapids'
+      fill_in 'Supporting Act', with: 'LA Galaxy'
+      fill_in 'Price', with: 44.99
+      fill_in 'Date', with: '2016/09/12'
+      select categories.first.title, from: 'Category'
       click_on 'Add Event'
 
       expect(current_path).to eq(event_path(Event.first.venue, Event.first))
-      expect(page).to have_content(Event.first.title)
-      expect(page).to have_content(Event.first.supporting_act)
-      expect(page).to have_content(Event.first.price)
+      expect(page).to have_content('Event Added Successfully!')
+      expect(page).to have_content('Colorado Rapids')
+      expect(page).to have_content('LA Galaxy')
+      expect(page).to have_content('$44.99')
+      expect(page).to have_content('09-12-2016')
       expect(page).to have_css("img[src*='#{Event.first.venue.image_path}']")
+      expect(venue.events.count).to eq(1)
     end
-  end
 
-  context 'with valid information and photo' do
-    scenario 'logged-in admin visits the events path' do
-      admin = create(:admin)
-      categories = create_list(:category, 3)
+    scenario 'with invalid event information' do
       venue = create(:venue)
+      admin = venue.admin
+      existing_event = create(:event)
 
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
-
-      visit events_path
-      click_on 'Add New Event'
-
-      fill_in 'Title', with: 'Creamy Ranch Dressing'
-      fill_in 'Supporting Act', with: "It's not self-indulgent when it's the best. By Newman, for Newman."
-      fill_in 'Price', with: 29.99
-      select "#{categories.first.title}", from: 'Category'
-      select "#{venue.name}", from: 'Venue'
-      # Commented out due to this being a static asset.
-      # attach_file('Image', '/Users/Ryan/Desktop/No_available_image.gif')
-      click_on 'Add Event'
-
-      expect(current_path).to eq(event_path(Event.first.venue, Event.first))
-      expect(page).to have_content(Event.first.title)
-      expect(page).to have_content(Event.first.supporting_act)
-      expect(page).to have_content(Event.first.price)
-      expect(page).to have_css("img[src*='#{Event.first.venue.image_path}']")
-    end
-  end
-
-  context 'with invalid event information' do
-    scenario 'logged-in admin visits the events path' do
-      admin = create(:admin)
-      event = create(:event)
-
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+      allow_any_instance_of(ApplicationController).
+        to receive(:current_user).
+        and_return(admin)
 
       visit events_path
       click_on 'Add New Event'
-      fill_in 'Title', with: event.title
-      fill_in 'Supporting Act', with: event.supporting_act
+      fill_in 'Title', with: existing_event.title
       click_on 'Add Event'
 
       expect(page).to have_content("Price can't be blank")
@@ -75,10 +58,54 @@ RSpec.feature 'Admin creates an event' do
     end
   end
 
+  # Test is skipped due to this functionality currently being tentative
+  # context 'with valid information and photo' do
+  #   scenario 'logged-in admin visits the events path' do
+  #     admin = create(:admin)
+  #     categories = create_list(:category, 3)
+  #     venue = create(:venue)
+  #
+  #     allow_any_instance_of(ApplicationController).
+  #       to receive(:current_user).
+  #       and_return(admin)
+  #
+  #     visit events_path
+  #     click_on 'Add New Event'
+  #
+  #     fill_in 'Title', with: 'Creamy Ranch Dressing'
+  #     fill_in 'Supporting Act', with: "It's not self-indulgent when it's the best. By Newman, for Newman."
+  #     fill_in 'Price', with: 29.99
+  #     select "#{categories.first.title}", from: 'Category'
+  #     select "#{venue.name}", from: 'Venue'
+  #     # Commented out due to this being a static asset.
+  #     # attach_file('Image', '/Users/Ryan/Desktop/No_available_image.gif')
+  #     click_on 'Add Event'
+  #
+  #     expect(current_path).to eq(event_path(Event.first.venue, Event.first))
+  #     expect(page).to have_content(Event.first.title)
+  #     expect(page).to have_content(Event.first.supporting_act)
+  #     expect(page).to have_content(Event.first.price)
+  #     expect(page).to have_css("img[src*='#{Event.first.venue.image_path}']")
+  #   end
+  # end
+
   context 'unauthorized user' do
+    scenario 'logged-in venue admin visits another venue new event path' do
+      venues = create_list(:venue, 2)
+      admin = venues.first.admin
+
+      allow_any_instance_of(ApplicationController).
+        to receive(:current_user).
+        and_return(admin)
+
+
+    end
+
     scenario 'logged-in user visits the events path' do
       user = create(:user)
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      allow_any_instance_of(ApplicationController).
+        to receive(:current_user).
+        and_return(user)
 
       visit events_path
 
@@ -87,7 +114,9 @@ RSpec.feature 'Admin creates an event' do
 
     scenario 'logged-in user attempts to visit new event path' do
       user = create(:user)
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      allow_any_instance_of(ApplicationController).
+        to receive(:current_user).
+        and_return(user)
 
       visit new_admin_event_path
 


### PR DESCRIPTION
- Sad paths for unauthorized users included in tests
- Venue admin can add events only to their own venue

@GSmes & @matthewrpacker: You'll notice that there are some things commented out - these are related to image upload functionality for an event. This existed in the Little Shop project, but we had discussed it only as an extension here, due to the nature of events and them now using the venue image. Just an FYI in case you notice comments and wonder why they were left in the code - it was intentional.
