### PR TITLE
Close #26. Venue admin can edit their events

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -1,5 +1,6 @@
 class Admin::EventsController < Admin::BaseController
   before_action :set_event, only: [:edit, :update]
+  before_action :verify_permissions, only: [:edit]
 
   def new
     @event = Event.new
@@ -20,8 +21,8 @@ class Admin::EventsController < Admin::BaseController
   end
 
   def update
-    if @event.update_attributes(event_params)
-      flash[:success] = "#{@event.title} updated successfully."
+    if @event.update_attributes(params_with_venue)
+      flash[:success] = "Event Updated Successfully!"
       @event.update_image_path
       redirect_to event_path(@event.venue, @event)
     else
@@ -53,4 +54,9 @@ class Admin::EventsController < Admin::BaseController
     @event = Event.find_by(slug: params[:id])
   end
 
+  def verify_permissions
+    unless current_user && @event.venue.admin == current_user
+      render file: '/public/404', status => 404, :layout => true
+    end
+  end
 end

--- a/app/views/venues/show.html.erb
+++ b/app/views/venues/show.html.erb
@@ -23,7 +23,10 @@
             <th>Category</th>
             <th>Date</th>
             <th>Price</th>
-            <th>Purchase</th>
+            <th class='text-center'>Purchase</th>
+            <% if this_venues_admin? %>
+              <th class='text-center'>Edit</th>
+            <% end %>
           </tr>
         </thead>
         <tbody>
@@ -34,10 +37,13 @@
               <td><%= event.event_date %></td>
               <td><%= number_to_currency(event.price) %></td>
               <td>
-                <%= content_tag :div do %>
-                  <%= button_to "Add to Cart", cart_events_path(event_id: event.id), class: "center_button btn btn-sm btn-primary" %>
-                <% end %>
+                <%= button_to "Add to Cart", cart_events_path(event_id: event.id), class: "btn btn-sm btn-primary" %>
               </td>
+              <% if this_venues_admin? %>
+                <td>
+                  <%= link_to 'Manage Event', edit_admin_event_path(event), class: 'btn btn-default btn-sm' %>
+                </td>
+              <% end %>
             </tr>
           <% end %>
         </tbody>

--- a/spec/features/admin/admin_can_edit_an_event_spec.rb
+++ b/spec/features/admin/admin_can_edit_an_event_spec.rb
@@ -2,24 +2,74 @@ require 'rails_helper'
 
 RSpec.feature "Admin can edit an event" do
   context "registered business admin" do
-    scenario "when they click Edit on events page" do
+    scenario "with valid event updates" do
       event = create(:event)
       admin = event.venue.admin
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+      allow_any_instance_of(ApplicationController).
+        to receive(:current_user).
+        and_return(admin)
 
-      visit events_path
+      visit admin_dashboard_index_path
+      click_on "View My Events"
 
       within("#event-#{event.id}") do
-        click_on "Edit"
+        click_on "Manage Event"
       end
 
       expect(current_path).to eq(edit_admin_event_path(event))
-      fill_in "Title", with: "Hairbrush"
+      fill_in "Title", with: "The Book of Mormon"
       click_on "Update Event"
 
       expect(current_path).to eq(event_path(Event.first.venue, Event.first))
+      expect(page).to have_content("Event Updated Successfully!")
+      within('.event-content') do
+        expect(page).to_not have_content(event.title)
+        expect(page).to have_content("The Book of Mormon")
+        expect(page).to have_content(event.venue_name)
+        expect(page).to have_content(event.category.title)
+        expect(page).to have_content(event.supporting_act)
+        expect(page).to have_content(event.event_date)
+        expect(page).to have_content(event.price)
+      end
+    end
 
-      expect(page).to have_content("Hairbrush")
+    scenario "with invalid event updates" do
+      event = create(:event)
+      admin = event.venue.admin
+      existing_event = Event.create(
+        title: "Already Here",
+        price: 9.99,
+        category: event.category,
+        venue: event.venue,
+        date: event.date,
+        supporting_act: event.supporting_act
+      )
+
+      allow_any_instance_of(ApplicationController).
+        to receive(:current_user).
+        and_return(admin)
+
+      visit edit_admin_event_path(event)
+      fill_in "Title", with: existing_event.title
+      fill_in "Date", with: existing_event.date
+      click_on "Update Event"
+
+      expect(page).to have_content('Title has already been taken')
+      expect(Event.first.title).to eq(event.title)
+    end
+
+    scenario "they attempt to edit another venue's event" do
+      events = create_list(:event, 2)
+      admin = events.first.venue.admin
+
+      allow_any_instance_of(ApplicationController).
+        to receive(:current_user).
+        and_return(admin)
+
+      visit edit_admin_event_path(Event.last)
+
+      expect(page).to_not have_content("Edit Event")
+      expect(page).to have_css('img[src*="http://i.imgur.com/F4zRA3g.jpg"]')
     end
   end
 
@@ -27,7 +77,9 @@ RSpec.feature "Admin can edit an event" do
     scenario "they attempt to visit the edit event path" do
       user = create(:user)
       event = create(:event)
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      allow_any_instance_of(ApplicationController).
+        to receive(:current_user).
+        and_return(user)
 
       visit edit_admin_event_path(event)
 


### PR DESCRIPTION
- Add functionality for a venue admin to edit their own venue's events
- Sad paths tested for venue admins and registered customers
