### PR TITLE
Close #29 Venue Admin can delete event.

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css
@@ -150,20 +150,8 @@
     color: rgb(85, 85, 85);
   }
 
-  .btn-danger {
-    background-color: rgb(200, 181, 80);
-    border-color: rgba(85, 85, 85, 0.4);
-    margin-bottom: 20px;
-    color: rgb(85, 85, 85);
-    margin-right: 25px;
-    font-weight: bold;
-  }
-
   .btn-danger:hover {
-    background-color: rgb(200, 181, 80);
-    border-color: rgba(85, 85, 85, 0.4);
-    margin-bottom: 20px;
-    color: rgb(85, 85, 85);
+    background-color: rgb(144, 0, 0);
   }
 
   h1 {

--- a/app/assets/stylesheets/flash_styling.css
+++ b/app/assets/stylesheets/flash_styling.css
@@ -5,9 +5,6 @@
   To use Glyphicons sprites instead of Font Awesome, replace with "require twitter-bootstrap-static/sprites"
   =require twitter-bootstrap-static/fontawesome
   */
-.alert {
-  padding-left: 200px;
-}
 
 /* Delete lines 16 & 17 if we want left-sidebar to overlap flash message when animation ends */
 .animated {

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -1,5 +1,6 @@
 class Admin::EventsController < Admin::BaseController
-  before_action :set_event, only: [:edit, :update]
+  before_action :set_event, only: [:edit, :update, :destroy]
+  before_action :verify_permissions, only: [:edit]
 
   def new
     @event = Event.new
@@ -20,14 +21,20 @@ class Admin::EventsController < Admin::BaseController
   end
 
   def update
-    if @event.update_attributes(event_params)
-      flash[:success] = "#{@event.title} updated successfully."
+    if @event.update_attributes(params_with_venue)
+      flash[:success] = "Event Updated Successfully!"
       @event.update_image_path
       redirect_to event_path(@event.venue, @event)
     else
       flash.now[:danger] = @event.errors.full_messages.join(', ')
       render :edit
     end
+  end
+
+  def destroy
+    @event.destroy
+    flash[:success] = "Event Removed Successfully!"
+    redirect_to venue_path(@event.venue)
   end
 
   private
@@ -50,7 +57,12 @@ class Admin::EventsController < Admin::BaseController
   end
 
   def set_event
-    @event = Event.find_by(slug: params[:id])
+    @event = Event.find_by_slug(params[:id])
   end
 
+  def verify_permissions
+    unless current_user && @event.venue.admin == current_user
+      render file: '/public/404', status => 404, :layout => true
+    end
+  end
 end

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -2,7 +2,7 @@
   <h1>All Events</h1>
   <%= render partial: "filter" %>
   <% if current_admin? %>
-    <%= link_to 'Add New Event', new_admin_event_path, class: 'btn btn-lg btn-danger pull-right' %>
+    <%= link_to 'Add New Event', new_admin_event_path, class: 'btn btn-lg btn-success pull-right' %>
   <% end %>
 
   <%= render partial: 'shared/event_list', locals: { btn_label: 'Add to Cart', btn_class: 'primary btn-sm', status: false} %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -16,8 +16,12 @@
         <p><%= link_to 'SOLD OUT', cart_events_path(event_id: @event.id), class: 'center_button btn btn-danger', disabled: 'disabled' %></p>
       <% else %>
         <p><%= button_to 'Add to Cart', cart_events_path(event_id: @event.id), class: 'center_button btn btn-primary' %></p>
+        <br />
         <% if current_admin? %>
-          <p><%= link_to 'Edit Event', edit_admin_event_path(@event), class: 'btn btn-default' %></p>
+          <p>
+            <%= link_to 'Edit Event', edit_admin_event_path(@event), class: 'btn btn-default' %>
+            <%= link_to "Delete Event", admin_event_path(@event), method: :delete, class: 'btn btn-sm btn-danger' %>
+          </>
         <% end %>
       <% end %>
     </div>

--- a/app/views/venues/show.html.erb
+++ b/app/views/venues/show.html.erb
@@ -11,7 +11,7 @@
       </p>
       <% if this_venues_admin? %>
         <p>
-          <%= link_to 'Add Event', new_admin_event_path, class: 'btn btn-default' %>
+          <%= link_to 'Add New Event', new_admin_event_path, class: 'center_button btn btn-success' %>
         </p>
       <% end %>
     </div>
@@ -23,7 +23,11 @@
             <th>Category</th>
             <th>Date</th>
             <th>Price</th>
-            <th>Purchase</th>
+            <th class='text-center'>Purchase</th>
+            <% if this_venues_admin? %>
+              <th class='text-center'>Edit</th>
+              <th class='text-center'>Delete</th>
+            <% end %>
           </tr>
         </thead>
         <tbody>
@@ -34,10 +38,16 @@
               <td><%= event.event_date %></td>
               <td><%= number_to_currency(event.price) %></td>
               <td>
-                <%= content_tag :div do %>
-                  <%= button_to "Add to Cart", cart_events_path(event_id: event.id), class: "center_button btn btn-sm btn-primary" %>
-                <% end %>
+                <%= button_to "Add to Cart", cart_events_path(event_id: event.id), class: "center_button btn btn-sm btn-primary" %>
               </td>
+              <% if this_venues_admin? %>
+                <td>
+                  <%= link_to 'Manage Event', edit_admin_event_path(event), class: 'center_button btn btn-sm btn-default' %>
+                </td>
+                <td>
+                  <%= button_to "Delete Event", admin_event_path(event), method: :delete, class: 'center_button btn btn-sm btn-danger' %>
+                </td>
+              <% end %>
             </tr>
           <% end %>
         </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,7 @@ Rails.application.routes.draw do
   root to: 'home#index'
   namespace :admin do
     resources :dashboard, only: [:index]
-    resources :events, only: [:new, :create, :edit, :update]
-    # get '/edit/:name', to: 'venues#edit', as: :edit_venue
+    resources :events, only: [:new, :create, :edit, :update, :destroy]
     resources :venues, param: :name, only: [:edit, :update]
   end
   resources :cart_events, only: [:create, :update, :destroy]

--- a/spec/features/admin/admin_can_delete_an_event_spec.rb
+++ b/spec/features/admin/admin_can_delete_an_event_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.feature "Admin can delete an event" do
+  context "registered Venue Admin" do
+    scenario "when they click Delete on venue show page" do
+      event = create(:event)
+      venue = event.venue
+      admin = venue.admin
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+      visit admin_dashboard_index_path
+
+      click_on "View My Events"
+
+      expect(current_path).to eq(venue_path(venue))
+
+      within("#event-#{event.id}") do
+        click_on "Delete Event"
+      end
+
+      expect(current_path).to eq(venue_path(venue))
+      expect(page).to have_content("Event Removed Successfully!")
+      expect(page).to_not have_content(event.title)
+    end
+
+    scenario "when they click Delete on specific event show page" do
+      event = create(:event)
+      venue = event.venue
+      admin = venue.admin
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+      visit event_path(event.venue, event)
+
+      click_on "Delete Event"
+
+      expect(current_path).to eq(venue_path(venue))
+      expect(page).to have_content("Event Removed Successfully!")
+      expect(page).to_not have_content(event.title)
+    end
+  end
+
+  context "registered customer" do
+    scenario "they visit the venue show page" do
+      user = create(:user)
+      event = create(:event)
+      venue = event.venue
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit venue_path(venue)
+
+      expect(page).to_not have_button("Delete Event")
+    end
+
+    scenario "they visit the event show page" do
+      user = create(:user)
+      event = create(:event)
+      venue = event.venue
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit event_path(event.venue, event)
+
+      expect(page).to_not have_button("Delete Event")
+    end
+  end
+end

--- a/spec/features/admin/admin_creates_an_event_spec.rb
+++ b/spec/features/admin/admin_creates_an_event_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Admin creates an event' do
 
       visit admin_dashboard_index_path
       click_on 'View My Events'
-      click_on 'Add Event'
+      click_on 'Add New Event'
 
       expect(current_path).to eq(new_admin_event_path)
       within('form') do
@@ -109,7 +109,7 @@ RSpec.feature 'Admin creates an event' do
 
       visit events_path
 
-      expect(page).to_not have_link('Add New Event')
+      expect(page).to_not have_button('Add New Event')
     end
 
     scenario 'logged-in user attempts to visit new event path' do
@@ -127,7 +127,7 @@ RSpec.feature 'Admin creates an event' do
     scenario 'visitor visits the events path' do
       visit events_path
 
-      expect(page).to_not have_link('Add New Event')
+      expect(page).to_not have_button('Add New Event')
     end
 
     scenario 'visitor attempts to visit new event path' do


### PR DESCRIPTION
@ryanflach & @matthewrpacker : See below for changes. All tests are passing with all of these changes in place.
- Add admin namespaced route to destroy for events.
- Add controller method for delete in Admin/events_contoller.
- Add delete button to event show page when user is admin.
- Add delete button to event list on venue show page when user is admin.
- Add admin_can_delete_an_event_spec to test event deletion functionality.
- Make buttons for adding event all match (i.e., display Add New Event & make button green).
- Update admin_creates_an_event_spec to reflect the renaming of buttons to Add New Event.
- Updated flash_styling after noticing flash messages weren't centered.
