### PR TITLE
Close #113. Close #114. Add status to venue, update seeds

### DIFF
--- a/app/controllers/venues_controller.rb
+++ b/app/controllers/venues_controller.rb
@@ -1,11 +1,11 @@
 class VenuesController < ApplicationController
   def index
-    @venues = Venue.all
+    @venues = Venue.where(status: 0)
   end
 
   def show
     @venue = Venue.find_by(slug: params[:name])
-    if @venue.nil?
+    if @venue.nil? || @venue.offline?
       render file: '/public/404', status => 404, :layout => true
     end
   end

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -1,5 +1,5 @@
 class Venue < ApplicationRecord
-  has_many :events
+  has_many :events, dependent: :destroy
   has_many :categories, through: :events
   belongs_to :admin, class_name: "User", foreign_key: :user_id
   validates :name, presence: true, uniqueness: true
@@ -8,6 +8,8 @@ class Venue < ApplicationRecord
   validates :state, presence: true
   validates :slug, presence: true, uniqueness: { case_sensitive: false }
   before_validation :create_slug
+
+  enum status: %w(online offline)
 
   def location
     "#{city}, #{state}"

--- a/db/migrate/20160823222736_add_status_to_venue.rb
+++ b/db/migrate/20160823222736_add_status_to_venue.rb
@@ -1,0 +1,5 @@
+class AddStatusToVenue < ActiveRecord::Migration[5.0]
+  def change
+    add_column :venues, :status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160822201502) do
+ActiveRecord::Schema.define(version: 20160823222736) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 20160822201502) do
     t.integer  "capacity"
     t.string   "slug"
     t.integer  "user_id"
+    t.integer  "status"
     t.index ["user_id"], name: "index_venues_on_user_id", using: :btree
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -52,7 +52,8 @@ class Seed
       city: 'Chicago',
       state: 'IL',
       capacity: 41268,
-      image_path: 'http://i.imgur.com/NqWzxPB.jpg'
+      image_path: 'http://i.imgur.com/NqWzxPB.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
     Venue.create!(
@@ -60,7 +61,8 @@ class Seed
       city: 'Morrison',
       state: 'CO',
       capacity: 9525,
-      image_path: 'http://i.imgur.com/JGQP86m.jpg'
+      image_path: 'http://i.imgur.com/JGQP86m.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
     Venue.create!(
@@ -68,7 +70,8 @@ class Seed
       city: 'Bronx',
       state: 'NY',
       capacity: 54251,
-      image_path: 'http://i.imgur.com/6kpS9z5.jpg'
+      image_path: 'http://i.imgur.com/6kpS9z5.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
     Venue.create!(
@@ -76,7 +79,8 @@ class Seed
       city: 'Denver',
       state: 'CO',
       capacity: 5000,
-      image_path: 'http://i.imgur.com/SIccgUE.jpg'
+      image_path: 'http://i.imgur.com/SIccgUE.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
     Venue.create!(
@@ -84,7 +88,8 @@ class Seed
       city: 'Los Angeles',
       state: 'CA',
       capacity: 2265,
-      image_path: 'http://i.imgur.com/3FT6OWs.jpg'
+      image_path: 'http://i.imgur.com/3FT6OWs.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
     Venue.create!(
@@ -92,7 +97,8 @@ class Seed
       city: 'New York',
       state: 'NY',
       capacity: 2804,
-      image_path: 'http://i.imgur.com/7kSGPAh.jpg'
+      image_path: 'http://i.imgur.com/7kSGPAh.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
     Venue.create!(
@@ -100,7 +106,8 @@ class Seed
       city: 'Sydney',
       state: 'AU',
       capacity: 6000,
-      image_path: 'http://i.imgur.com/ZhZQ5qw.jpg'
+      image_path: 'http://i.imgur.com/ZhZQ5qw.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
     Venue.create!(
@@ -108,7 +115,8 @@ class Seed
       city: 'New York',
       state: 'NY',
       capacity: 18200,
-      image_path: 'http://i.imgur.com/AlRnvKR.jpg'
+      image_path: 'http://i.imgur.com/AlRnvKR.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
     Venue.create!(
@@ -116,7 +124,8 @@ class Seed
       city: 'Denver',
       state: 'CO',
       capacity: 18007,
-      image_path: 'http://i.imgur.com/7OeaBay.jpg'
+      image_path: 'http://i.imgur.com/7OeaBay.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
     Venue.create!(
@@ -124,7 +133,8 @@ class Seed
       city: 'George',
       state: 'WA',
       capacity: 27500,
-      image_path: 'http://i.imgur.com/Mzv1JU5.jpg'
+      image_path: 'http://i.imgur.com/Mzv1JU5.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
     Venue.create!(
@@ -132,7 +142,8 @@ class Seed
       city: 'New York',
       state: 'NY',
       capacity: 5251,
-      image_path: 'http://i.imgur.com/APMN5QN.jpg'
+      image_path: 'http://i.imgur.com/APMN5QN.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
     Venue.create!(
@@ -140,7 +151,8 @@ class Seed
       city: 'San Diego',
       state: 'CA',
       capacity: 125000,
-      image_path: 'http://i.imgur.com/81CNDWf.jpg'
+      image_path: 'http://i.imgur.com/81CNDWf.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
     Venue.create!(
@@ -148,7 +160,8 @@ class Seed
       city: 'State College',
       state: 'PA',
       capacity: 107282,
-      image_path: 'http://i.imgur.com/9OcLwCU.jpg'
+      image_path: 'http://i.imgur.com/9OcLwCU.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
     Venue.create!(
@@ -156,7 +169,8 @@ class Seed
       city: 'Glendale',
       state: 'AZ',
       capacity: 63400,
-      image_path: 'http://i.imgur.com/niiHcUO.jpg'
+      image_path: 'http://i.imgur.com/niiHcUO.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
     Venue.create!(
@@ -164,7 +178,8 @@ class Seed
       city: 'St. Paul',
       state: 'MN',
       capacity: 17000,
-      image_path: 'http://i.imgur.com/zIJMgUm.jpg'
+      image_path: 'http://i.imgur.com/zIJMgUm.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
     Venue.create!(
@@ -172,7 +187,8 @@ class Seed
       city: 'Pittsburgh',
       state: 'PA',
       capacity: 38362,
-      image_path: 'http://i.imgur.com/ZhpUui3.jpg'
+      image_path: 'http://i.imgur.com/ZhpUui3.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
     Venue.create!(
@@ -180,7 +196,8 @@ class Seed
       city: 'Arlington',
       state: 'TX',
       capacity: 80000,
-      image_path: 'http://i.imgur.com/Q5qbKTi.jpg'
+      image_path: 'http://i.imgur.com/Q5qbKTi.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
     Venue.create!(
@@ -188,7 +205,8 @@ class Seed
       city: 'Pyongyang',
       state: 'NK',
       capacity: 150000,
-      image_path: 'http://i.imgur.com/LqQAAeN.jpg'
+      image_path: 'http://i.imgur.com/LqQAAeN.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
     Venue.create!(
@@ -196,7 +214,8 @@ class Seed
       city: 'Manila',
       state: 'PI',
       capacity: 20000,
-      image_path: 'http://i.imgur.com/hRFfDRE.jpg'
+      image_path: 'http://i.imgur.com/hRFfDRE.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
     Venue.create!(
@@ -204,7 +223,8 @@ class Seed
       city: 'Barcelona',
       state: 'SP',
       capacity: 99354,
-      image_path: 'http://i.imgur.com/piLqdVD.jpg'
+      image_path: 'http://i.imgur.com/piLqdVD.jpg',
+      status: 0
       )
       puts "Venue #{Venue.last.name} created."
   end
@@ -242,7 +262,7 @@ class Seed
       email: "nate@turing.io",
       password: "password",
     )
-    User.last.roles << Role.find_by(name: 'venue_admin')
+    User.last.roles << Role.where.not(name: 'platform_admin')
     puts "Venue Admin Nate created."
   end
 
@@ -296,7 +316,7 @@ class Seed
       email: "jorge@turing.io",
       password: "password",
     )
-    User.last.roles << Role.where.not(name: 'registered_customer')
+    User.last.roles << Role.all
     puts "Platform Admin Jorge created."
   end
 end

--- a/spec/features/venue/user_views_all_venues_spec.rb
+++ b/spec/features/venue/user_views_all_venues_spec.rb
@@ -10,4 +10,12 @@ RSpec.feature 'User views all venues' do
     expect(page).to have_content(venues.first.name)
     expect(page).to have_content(venues.last.name)
   end
+
+  scenario 'offline venue' do
+    offline_venue = create(:offline_venue)
+
+    visit venues_path
+
+    expect(page).to_not have_content(offline_venue.name)
+  end
 end

--- a/spec/features/venue/user_views_venue_show_page_spec.rb
+++ b/spec/features/venue/user_views_venue_show_page_spec.rb
@@ -16,4 +16,12 @@ RSpec.feature 'User views a venue show page' do
     expect(page).to have_content(venues.first.capacity)
     expect(page).not_to have_content(venues.last.name)
   end
+
+  scenario 'offline venue' do
+    offline_venue = create(:offline_venue)
+
+    visit venue_path(offline_venue)
+
+    expect(page).to have_css('img[src*="http://i.imgur.com/F4zRA3g.jpg"]')
+  end
 end

--- a/spec/models/venue_spec.rb
+++ b/spec/models/venue_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Venue, type: :model do
   it { should validate_presence_of :name }
   it { should validate_uniqueness_of :name }
-  it { should have_many :events }
+  it { should have_many(:events).dependent(:destroy) }
   it { should have_many(:categories).through(:events) }
   it { should validate_presence_of :image_path }
   it { should validate_presence_of :city }
@@ -14,5 +14,12 @@ RSpec.describe Venue, type: :model do
   it "should be able to display its location" do
     venue = create(:venue)
     expect(venue.location).to eq("#{venue.city}, #{venue.state}")
+  end
+
+  it "can have status of online or offline" do
+    online = create(:venue)
+    offline = create(:offline_venue)
+    expect(online.status).to eq('online')
+    expect(offline.status).to eq('offline')
   end
 end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -19,6 +19,10 @@ FactoryGirl.define do
     state 'CO'
     capacity 500
     admin { create(:venue_admin) }
+    status 0
+    factory :offline_venue do
+      status 1
+    end
   end
 
   factory :category do


### PR DESCRIPTION
- Add status column to venues table (mapped to enum with 'online' and 'offline')
- Venues only show online venues
- Update seed file to appropriately assign admins roles to include registered customer
