### PR TITLE
Close #109. Close #118. Blank order history & Sell With Us button.

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css
@@ -21,6 +21,12 @@
     margin-top: 10%;
   }
 
+  .center-order {
+    width: 70%;
+    margin-left: 15%;
+    text-align: center;
+  }
+
   .padded {
     width: 95%;
   }
@@ -28,7 +34,6 @@
   .pad-right {
     padding-right: 10%;
   }
-
 
   .float-left {
     float: left;
@@ -49,6 +54,39 @@
     padding-right: 25px;
     padding-bottom: 25px;
     float: left;
+  }
+
+  .cry-image {
+    min-width: 30%;
+  }
+
+  #homepage {
+    margin-top: 7%;
+    background: none;
+    border: none;
+  }
+
+  #dashboard {
+    margin-top: 0;
+    background: none;
+    border: none;
+  }
+
+  .sell-btn {
+    text-align: center;
+    padding-top: 30px;
+  }
+
+  .shadow {
+    -moz-box-shadow: 1px 1px 1px 1px rgba(46,46,46, 0.2);
+    -webkit-box-shadow: 1px 1px 1px 1px rgba(46,46,46, 0.2);
+    box-shadow: 1px 1px 1px 1px rgba(46,46,46, 0.2);
+  }
+
+  .shadow:hover {
+    -moz-box-shadow: 2px 2px 2px 2px rgba(46,46,46, 0.3);
+    -webkit-box-shadow: 2px 2px 2px 2px rgba(46,46,46, 0.3);
+    box-shadow: 2px 2px 2px 2px rgba(46,46,46, 0.3);
   }
 
   .fit-width {
@@ -130,14 +168,10 @@
     overflow: hidden;
   }
 
-  a {
-    color: rgb(200, 181, 80);
-    text-shadow: 0px 0px 6px rgba(0, 0, 0, 0.1);
-  }
-
   a:hover {
     text-decoration: none;
-    color: rgb(59, 142, 174);
+    color: #3e46c7;
+    text-shadow: 1px 1px 1px rgba(46,46,46, 0.2);
   }
 
   .btn-warning {

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,15 +1,20 @@
-<div class="well col-md-8 center">
-  <center>
-    <h1><font face='Passion One' size="50px">Nosebleed Tickets</font></h1>
-    Nobody wants to sit so close to a basketball court that they can smell the players' sweat, or close enough to a stage that they might need to catch a crowd-surfing lead singer. Enjoy your favorite events the smart way, with <em>Nosebleed Tickets<sup><small>TM</small></sup></em>! No longer will you be forced to strain your neck or exhaust yourself with the constant head-turning needed to follow the action. From the nosebleeds, the entire event is within your view!<sup> *</sup>
-  </center>
-  <br><br>
-  <center><small>* <sub>Binoculars recommended (particularly the small kind with the handle, like you might expect to see in the audience at an opera or a ballet).</sub></small></center>
-</div>
-<div class="center">
-  <% if current_user %>
-    <%= link_to "Sell With Us", new_venue_path, class: "btn btn-lg btn-primary" %>
+<div class="well center" id="homepage">
+  <div class="well fit-width">
+    <center>
+      <h1><font face='Passion One' size="50px">Nosebleed Tickets</font></h1>
+      Nobody wants to sit so close to a basketball court that they can smell the players' sweat, or close enough to a stage that they might need to catch a crowd-surfing lead singer. Enjoy your favorite events the smart way, with <em>Nosebleed Tickets<sup><small>TM</small></sup></em>! No longer will you be forced to strain your neck or exhaust yourself with the constant head-turning needed to follow the action. From the nosebleeds, the entire event is within your view!<sup> *</sup>
+    </center>
+    <br><br>
+    <center><small>* <sub>Binoculars recommended (particularly the small kind with the handle, like you might expect to see in the audience at an opera or a ballet).</sub></small></center>
+  </div>
+  <% if current_user && !current_admin? %>
+    <div class="sell-btn">
+      <%= link_to "Sell With Us", new_venue_path, class: "btn btn-lg btn-primary shadow" %>
+    </div>
+  <% elsif !current_user %>
+    <div class="sell-btn">
+      <%= link_to "Sell With Us", login_path, class: "btn btn-lg btn-primary shadow" %>
+    </div>
   <% else %>
-    <%= link_to "Sell With Us", login_path, class: "btn btn-lg btn-primary" %>
   <% end %>
 </div>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,52 +1,62 @@
 <div class="page-content">
   <h1>Order History</h1>
-  <% @orders.each do |order| %>
-    <div class="well col-md-8 table-responsive" id="order-<%= order.id %>">
-      <table class="table">
-        <thead>
-          <tr>
-            <td colspan="5" class="text-left">
-              <strong>Order # <%= order.id %></strong>
-            </td>
-          <tr>
-            <th>Date Placed</th>
-            <th>Number of Events</th>
-            <th>Total Tickets</th>
-            <th>Total</th>
-            <th>Status</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><%= order.date %></td>
-            <td><%= order.total_events %></td>
-            <td><%= order.total_tickets %></td>
-            <td><%= number_to_currency(order.total) %></td>
-            <td><%= order.status %></td>
-          </tr>
-          <td colspan="5" class="text-right">
-            <p><strong><%= link_to "Order Details", order_path(order), class:'btn btn-primary' %></strong></p>
-            <% if order.ordered? %>
-              <%= form_tag charges_path do %>
-                <%= hidden_field_tag :orderid, order.id %>
-                <article>
-                  <% if flash[:error].present? %>
-                    <div id="error_explanation">
-                      <p><%= flash[:error] %></p>
-                    </div>
-                  <% end %>
-                </article>
-                <script src="https://checkout.stripe.com/checkout.js" class="stripe-button"
-                  data-key="<%= Rails.configuration.stripe[:publishable_key] %>"
-                  data-description="Order #<%= order.id %>"
-                  data-amount="<%= order.total_in_cents %>"
-                  data-locale="auto">
-                </script>
-              <% end %>
-            <% end %>
-          </td>
-        </tbody>
-      </table>
+  <% if @orders.empty? %>
+    <div class="well center-order">
+      <center>
+        <h2>You have no orders yet</h2>
+        <div><%= image_tag("https://i.imgur.com/ldtpOON.gif", class: 'cry-image') %></div>
+        <h3>Time to make some memories at one of the many incredible <%= link_to "events", events_path %> coming soon!</h3>
+      </center>
     </div>
+  <% else %>
+    <% @orders.each do |order| %>
+      <div class="well col-md-8 table-responsive" id="order-<%= order.id %>">
+        <table class="table">
+          <thead>
+            <tr>
+              <td colspan="5" class="text-left">
+                <strong>Order # <%= order.id %></strong>
+              </td>
+            <tr>
+              <th>Date Placed</th>
+              <th>Number of Events</th>
+              <th>Total Tickets</th>
+              <th>Total</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><%= order.date %></td>
+              <td><%= order.total_events %></td>
+              <td><%= order.total_tickets %></td>
+              <td><%= number_to_currency(order.total) %></td>
+              <td><%= order.status %></td>
+            </tr>
+            <td colspan="5" class="text-right">
+              <p><strong><%= link_to "Order Details", order_path(order), class:'btn btn-primary' %></strong></p>
+              <% if order.ordered? %>
+                <%= form_tag charges_path do %>
+                  <%= hidden_field_tag :orderid, order.id %>
+                  <article>
+                    <% if flash[:error].present? %>
+                      <div id="error_explanation">
+                        <p><%= flash[:error] %></p>
+                      </div>
+                    <% end %>
+                  </article>
+                  <script src="https://checkout.stripe.com/checkout.js" class="stripe-button"
+                    data-key="<%= Rails.configuration.stripe[:publishable_key] %>"
+                    data-description="Order #<%= order.id %>"
+                    data-amount="<%= order.total_in_cents %>"
+                    data-locale="auto">
+                  </script>
+                <% end %>
+              <% end %>
+            </td>
+          </tbody>
+        </table>
+      </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/shared/_dashboard.html.erb
+++ b/app/views/shared/_dashboard.html.erb
@@ -1,49 +1,49 @@
-<div class="well table-responsive row col-md-6">
-  <table class="table" id="user_dashboard">
-    <tr>
-      <th>Username</th>
-      <td><%= current_user.username %></td>
-    </tr>
-    <tr>
-      <th>E-mail</th>
-      <td><%= current_user.email %></td>
-    </tr>
-    <tr>
-      <th>Date Registered</th>
-      <td><%= current_user.date_registered %></td>
-    </tr>
-    <% if venue_admin_only? %>
+<div class="well center" id="dashboard">
+  <div class="well table-responsive fit-width">
+    <table class="table" id="user_dashboard">
       <tr>
-        <th>Venue</th>
-        <td><%= @venue.name %></td>
+        <th>Username</th>
+        <td><%= current_user.username %></td>
       </tr>
-    <% else %>
       <tr>
-        <th>Orders Placed</th>
-        <td><%= current_user.orders.count %></td>
+        <th>E-mail</th>
+        <td><%= current_user.email %></td>
       </tr>
-    <% end %>
-  </table>
-  <div class='row col-md-6'>
-    <%= link_to 'View My Orders', orders_path, class: 'btn btn-default pull-right' unless current_admin?%>
-    <%= link_to 'Manage My Account', edit_user_path(current_user), class: 'btn btn-default' %>
-    <%= link_to 'Manage Venue', edit_admin_venue_path(name: @venue.slug), class: 'btn btn-default' if venue_admin_only? %>
-    <%= link_to 'View My Events', venue_path(name: @venue.slug), class: 'btn btn-default' if venue_admin_only? %>
-    <%= link_to 'Manage Venues', venues_path, class: 'btn btn-default' if platform_admin? %>
-  </div>
-</div>
-
-<% if !current_admin? %>
-  <div class="center">
-    <%= link_to "Sell With Us", new_venue_path, class: "btn btn-lg btn-primary" %>
-  </div>
-<% end %>
-
-<% if platform_admin? %>
-<br />
-  <div class="well table-responsive row col-md-7">
-    <h2>Pending Venues</h2>
-    <table class="table">
+      <tr>
+        <th>Date Registered</th>
+        <td><%= current_user.date_registered %></td>
+      </tr>
+      <% if venue_admin_only? %>
+        <tr>
+          <th>Venue</th>
+          <td><%= @venue.name %><%= link_to 'Manage Venue', edit_admin_venue_path(name: @venue.slug), class: 'btn btn-sm btn-default pull-right' %></td>
+        </tr>
+      <% else %>
+        <tr>
+          <th>Orders Placed</th>
+          <td><%= current_user.orders.count %><%= link_to 'View My Orders', orders_path, class: 'btn btn-sm btn-default pull-right' unless current_admin?%></td>
+        </tr>
+      <% end %>
     </table>
+    <div class='row col-md-6'>
+      <%= link_to 'Manage My Account', edit_user_path(current_user), class: 'btn btn-default' %>
+      <%= link_to 'View My Events', venue_path(name: @venue.slug), class: 'btn btn-default' if venue_admin_only? %>
+      <%= link_to 'Manage Venues', venues_path, class: 'btn btn-default' if platform_admin? %>
+    </div>
   </div>
-<% end %>
+
+  <% if !current_admin? %>
+    <div class="sell-btn">
+      <%= link_to "Sell With Us", new_venue_path, class: "btn btn-lg btn-primary shadow" %>
+    </div>
+  <% end %>
+
+  <% if platform_admin? %>
+  <br />
+    <div class="well table-responsive row col-md-7">
+      <h2>Pending Venues</h2>
+      <table class="table">
+      </table>
+    </div>
+  <% end %>
+</div>

--- a/spec/features/user/user_can_view_past_orders_spec.rb
+++ b/spec/features/user/user_can_view_past_orders_spec.rb
@@ -1,24 +1,39 @@
 require 'rails_helper'
 
 RSpec.feature "User can view past orders" do
-  scenario "when they go to their Order History page" do
-    user = create(:user)
-    create(:event)
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+  context "they go to their Order History page" do
+    scenario "when they have previous orders" do
+      user = create(:user)
+      create(:event)
+      allow_any_instance_of(ApplicationController).
+        to receive(:current_user).
+        and_return(user)
 
-    visit events_path
-    click_on "Add to Cart"
-    click_on "Add to Cart"
+      visit events_path
 
-    visit cart_index_path
-    click_on "Checkout"
+      click_on "Add to Cart"
+      click_on "Add to Cart"
 
-    order = Order.first
+      visit cart_index_path
 
-    within("#order-#{order.id}") do
-      expect(page).to have_content(order.date)
-      expect(page).to have_content(order.total_tickets)
-      expect(page).to have_content(order.total)
+      click_on "Checkout"
+
+      order = Order.first
+
+      within("#order-#{order.id}") do
+        expect(page).to have_content(order.date)
+        expect(page).to have_content(order.total_tickets)
+        expect(page).to have_content(order.total)
+      end
+    end
+
+    scenario "when they don't have any previous orders" do
+      user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit orders_path
+
+      expect(page).to have_content("You have no orders yet Time to make some memories at one of the many incredible events coming soon!")
     end
   end
 end


### PR DESCRIPTION
@matthewrpacker @ryanflach : See below for changes I made. I changed the color of links and added a very faint shadow to them when you hover over them. I also fixed the location of the Sell With Us button in both views in which it occurs.
- Add message to display on a user's Order History page when the user has no orders yet.
- Add test for the empty Order History message in user_can_view_past_orders_spec.
- Update CSS and HTML in dashboard partial so content is centered & organized more logically (moved 2 buttons).
- Update how links are displayed.
- Center & lower the Sell With Us button in both the Homepage and the Dashboard.
- Add logic to remove the Sell With Us button from the Homepage for Admins.
