### PR TITLE
Close #126. Update event index edit buttons

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,7 +26,9 @@ class ApplicationController < ActionController::Base
   end
 
   def current_admins_venue
-    Venue.find_by(admin: current_user) if current_user.venue_admin?
+    if current_user
+      Venue.find_by(admin: current_user) if current_user.venue_admin?
+    end
   end
 
   def categories

--- a/app/views/shared/_event_list.html.erb
+++ b/app/views/shared/_event_list.html.erb
@@ -30,7 +30,7 @@
               <td>
                   <%= button_to "#{btn_label}", cart_events_path(event_id: event.id), class: "center_button btn btn-#{btn_class}", disabled: status %>
               </td>
-              <% if venue_admin? %>
+              <% if platform_admin? || event.venue == current_admins_venue %>
                 <td>
                   <%= link_to "Edit", edit_admin_event_path(event), class: "center_button btn btn-default" %>
                 </td>

--- a/spec/features/admin/admin_can_edit_an_event_spec.rb
+++ b/spec/features/admin/admin_can_edit_an_event_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature "Admin can edit an event" do
-  context "registered business admin" do
-    scenario "with valid event updates" do
+  context "registered venue admin" do
+    scenario "they visit their dashboard with valid event updates" do
       event = create(:event)
       admin = event.venue.admin
       allow_any_instance_of(ApplicationController).

--- a/spec/features/admin/admin_sees_edit_button_on_events_index_spec.rb
+++ b/spec/features/admin/admin_sees_edit_button_on_events_index_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.feature "Admin sees edit button on events index" do
+  context "logged-in venue admin" do
+    scenario "they only see an edit button for their events" do
+      events = create_list(:event, 2)
+      admin = events.first.venue.admin
+      allow_any_instance_of(ApplicationController).
+        to receive(:current_user).
+        and_return(admin)
+
+      visit events_path
+
+      within("#event-#{events.first.id}") do
+        expect(page).to have_link("Edit")
+      end
+
+      within("#event-#{events.last.id}") do
+        expect(page).to_not have_link("Edit")
+      end
+    end
+  end
+
+  context "logged-in platform admin" do
+    scenario "they see an edit button for all events" do
+      events = create_list(:event, 2)
+      admin = create(:platform_admin)
+      allow_any_instance_of(ApplicationController).
+        to receive(:current_user).
+        and_return(admin)
+
+      visit events_path
+
+      within("#event-#{events.first.id}") do
+        expect(page).to have_link("Edit")
+      end
+
+      within("#event-#{events.last.id}") do
+        expect(page).to have_link("Edit")
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Edit button is only shown to platform admins or for events where the current user is the event's venue admin
